### PR TITLE
Fix Redis connection issues in backend services

### DIFF
--- a/backend/src/cqrs/jobs/command-job.service.ts
+++ b/backend/src/cqrs/jobs/command-job.service.ts
@@ -11,8 +11,20 @@ export class CommandJobService implements OnModuleInit {
   constructor(private readonly redisService: RedisService) {}
 
   async onModuleInit() {
-    // Start processing commands
-    this.startProcessing();
+    console.log('Command job service initializing...');
+    
+    // Delay startup to ensure Redis connection is established
+    setTimeout(async () => {
+      // Wait for Redis connection
+      const connected = await this.redisService.waitForConnection(15000);
+      
+      if (connected) {
+        console.log('Redis connected, starting command job service');
+        this.startProcessing();
+      } else {
+        console.error('Redis connection failed, command job service will not start');
+      }
+    }, 2000); // Delay 2 seconds before checking connection
   }
 
   private async startProcessing() {
@@ -33,7 +45,8 @@ export class CommandJobService implements OnModuleInit {
         }
       } catch (error) {
         console.error('Error processing command:', error);
-        // Continue processing even if there's an error
+        // Add a short delay to prevent tight loop in case of persistent errors
+        await new Promise(resolve => setTimeout(resolve, 1000));
       }
     }
   }

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Ensure Redis is running
+echo "Checking Redis connection..."
+if command -v redis-cli &> /dev/null; then
+  if ! redis-cli ping &> /dev/null; then
+    echo "Redis is not running. Starting Redis..."
+    if command -v docker &> /dev/null; then
+      docker run --name redis -p 6379:6379 -d redis || echo "Failed to start Redis with Docker"
+    else
+      echo "Please start Redis manually before running the application"
+    fi
+  else
+    echo "Redis is running"
+  fi
+else
+  echo "redis-cli not found. Please ensure Redis is running"
+fi
+
+# Set NODE_PATH and start the application
+echo "Starting application..."
+NODE_PATH=./dist node dist/backend/src/main.js


### PR DESCRIPTION
## Description
This PR fixes Redis connection issues in the backend services that were causing errors during application startup.

### Changes
- Added a `waitForConnection` method to the Redis service to properly handle connection establishment
- Modified all Redis operations to check for connection status before proceeding
- Added error handling in the `blockingPopFromList` method to prevent crashes
- Updated the command job service to wait for Redis connection before starting
- Added a delay in the command job service initialization to ensure Redis is ready
- Created a startup script (`start.sh`) that checks for Redis availability before starting the application

### Problem Solved
Previously, the application would throw errors on startup because the command job service was trying to use Redis before the connection was established:
```
Error processing command: TypeError: Cannot read properties of undefined (reading 'brPop')
```

With these changes, the application now properly waits for Redis to be connected before attempting to use it, making the startup process more robust.

### Testing
The changes have been tested locally and the application now starts without Redis-related errors.

### Notes
- The startup script also includes logic to check if Redis is running and attempts to start it using Docker if available
- Added error handling and retry mechanisms to prevent tight loops in case of persistent errors

@linkerlin can click here to [continue refining the PR](https://app.all-hands.dev/conversations/115232d20be64242bc3ab7372c1d9701)